### PR TITLE
chore: Add GetJsonTopPostsByID

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -9,6 +9,11 @@ import (
 	"gno.land/r/demo/users"
 )
 
+type UserAndPostID struct {
+	UserPostAddr std.Address
+	PostID       PostID
+}
+
 // Post a message to the caller's main user posts.
 // The caller must already be registered with /r/demo/users Register.
 // Return the "thread ID" of the new post.
@@ -86,6 +91,40 @@ func RepostThread(userPostsAddr std.Address, threadid PostID, comment string) Po
 	}
 	repost := thread.AddRepostTo(caller, comment, dstUserPosts)
 	return repost.id
+}
+
+// For each address/PostID in addrAndIDs, get the thread post. The Post ID must be
+// for a a top-level thread (not a reply; to get reply posts, use GetThreadPosts).
+// If the Post ID is not found, set the result for that Post ID to {}.
+// The response is a JSON string.
+func GetJsonTopPostsByID(addrAndIDs []UserAndPostID) string {
+	json := "[ "
+	for _, addrAndID := range addrAndIDs {
+		if len(json) > 2 {
+			json += ",\n  "
+		}
+
+		userPosts := getUserPosts(addrAndID.UserPostAddr)
+		if userPosts == nil {
+			json += "{}"
+			continue
+		}
+
+		post := userPosts.GetThread(PostID(addrAndID.PostID))
+		if post == nil {
+			json += "{}"
+			continue
+		}
+
+		postJson, err := post.MarshalJSON()
+		if err != nil {
+			panic("can't get post JSON")
+		}
+		json += string(postJson)
+	}
+	json += "]"
+
+	return json
 }
 
 // Get posts in a thread for a user. A thread is the sequence of posts without replies.


### PR DESCRIPTION
We already have [`GetThreadPosts`](https://github.com/gnolang/dsocial/blob/faf388890cdff5f43e81680777b5d6ca891b9ec5/realm/public.gno#L91-L100) which is good to use an index range to get the posts in-order of a thread (or reply thread). But the home feed includes followed posts inserted at any point in the feed. We need a way to get arbitrary top-level posts by Post ID. This PR adds `GetJsonTopPostsByID`.

Tested in the GnoSoclal demo app with the following code:
```
const result = await gno.qEval("gno.land/r/berty/social", "GetJsonTopPostsByID([]UserAndPostID{" + 
  `{"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", 1}, ` + 
  `{"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", 3}, ` + "})");
if (!(result.startsWith('(') && result.endsWith(' string)'))) throw new Error("Malformed GetJsonTopPostsByID response");
const quoted = result.substring(1, result.length - ' string)'.length);
const json = JSON.parse(quoted);
const info = JSON.parse(json);
```

 Example value of `json`:
```
[ {"id": 1, "createdAt": "2024-04-23T15:46:36Z", "creator": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", "n_replies": 0, "n_replies_all": 0, "parent_id": 0, "body": "test_1 first"},
  {"id": 3, "createdAt": "2024-04-23T15:49:38Z", "creator": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", "n_replies": 0, "n_replies_all": 0, "parent_id": 0, "body": "test_1 third"}]
```