### PR TITLE
chore: In Follow, return the value of startedPostsCtr in the added FollowingInfo

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -226,7 +226,7 @@ func GetJsonHomePosts(userPostsAddr std.Address, startIndex int, endIndex int) s
 }
 
 // Update the caller to follow the user with followedAddr. See UserPosts.Follow.
-func Follow(followedAddr std.Address) {
+func Follow(followedAddr std.Address) PostID {
 	std.AssertOriginCall()
 	caller := std.GetOrigCaller()
 	name := usernameOf(caller)
@@ -240,7 +240,7 @@ func Follow(followedAddr std.Address) {
 
 	// A user can follow someone before doing any posts, so create the UserPosts if needed.
 	userPosts := getOrCreateUserPosts(caller, name)
-	userPosts.Follow(followedAddr)
+	return userPosts.Follow(followedAddr)
 }
 
 // Update the caller to unfollow the user with followedAddr. See UserPosts.Unfollow.

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -68,15 +68,16 @@ func (userPosts *UserPosts) AddThread(body string) *Post {
 	return thread
 }
 
-// If already following followedAddr, then do nothing.
+// If already following followedAddr, then do nothing and return 0.
 // If there is a UserPosts for followedAddr, then add it to following,
 // and add this user to its followers.
-// If there is no UserPosts for followedAddr, then do nothing. (We don't expect
+// If there is no UserPosts for followedAddr, then do nothing and return 0. (We don't expect
 // this because this is usually called by clicking on the display page of followedAddr.)
-func (userPosts *UserPosts) Follow(followedAddr std.Address) {
+// Return the value of startedPostsCtr in the added FollowingInfo.
+func (userPosts *UserPosts) Follow(followedAddr std.Address) PostID {
 	if userPosts.following.Has(followedAddr.String()) {
 		// Already following.
-		return
+		return PostID(0)
 	}
 
 	followedUserPosts := getUserPosts(followedAddr)
@@ -86,7 +87,10 @@ func (userPosts *UserPosts) Follow(followedAddr std.Address) {
 			startedPostsCtr:    PostID(postsCtr), // Ignore past messages.
 		})
 		followedUserPosts.followers.Set(userPosts.userAddr.String(), "")
+		return PostID(postsCtr)
 	}
+
+	return PostID(0)
 }
 
 // Remove followedAddr from following.


### PR DESCRIPTION
When `Follow` creates the `FollowingInfo`, it [sets `startedPostsCtr`](https://github.com/gnolang/dsocial/blob/3cef6166d556b6119b5d7da7e9b49d4aadef1941/realm/userposts.gno#L86) to the current value of the global posts counter. This is used when computing the user's home posts to only show the posts of a followed user after starting to follow. In the indexer, we want to scan the transactions for calls to `Follow` to make a copy of the list of users being followed, so the indexer needs to know the value of `startedPostsCtr`. Because it is returned from `Follow`, the indexer can look at the transaction result.