### PR TITLE
fix: In call to Follow, increase gasWanted

### DIFF
--- a/mobile/src/hooks/use-search.ts
+++ b/mobile/src/hooks/use-search.ts
@@ -11,7 +11,7 @@ export const useSearch = () => {
 
     try {
       const gasFee = "1000000ugnot";
-      const gasWanted = 2000000;
+      const gasWanted = 10000000;
       const args: Array<string> = [address];
       for await (const response of await gno.call("gno.land/r/berty/social", "Follow", args, gasFee, gasWanted)) {
         console.log("response: ", JSON.stringify(response));
@@ -26,7 +26,7 @@ export const useSearch = () => {
 
     try {
       const gasFee = "1000000ugnot";
-      const gasWanted = 2000000;
+      const gasWanted = 10000000;
       const args: Array<string> = [address];
       for await (const response of await gno.call("gno.land/r/berty/social", "Unfollow", args, gasFee, gasWanted)) {
         console.log("response: ", JSON.stringify(response));


### PR DESCRIPTION
If the user has already posted, then the user already has a dSocial user entry, and clicking on Follow just adds the Follow information. But if it is a new account, clicking on Follow also creates the dSocial user entry. This requires more gas. Therefore, this PR increases the gasWanted for Follow so that it doesn't fail in this case. (Also increase the gasWanted for Unfollow for symmetry.)