### PR TITLE
chore: In searchUser, add optional param excludeActiveAccount

### DIFF
--- a/mobile/app/home/search/index.tsx
+++ b/mobile/app/home/search/index.tsx
@@ -14,7 +14,7 @@ export default function Search() {
   useEffect(() => {
     (async function () {
       if (params.q) {
-        const result = await search.searchUser(params.q);
+        const result = await search.searchUser(params.q, true);
         setData(result);
       } else {
         setData([]);

--- a/mobile/src/hooks/use-search.ts
+++ b/mobile/src/hooks/use-search.ts
@@ -72,13 +72,21 @@ export const useSearch = () => {
     return json;
   }
 
-  async function searchUser(q: string) {
+  async function searchUser(q: string, excludeActiveAccount?: boolean) {
     checkActiveAccount();
 
     const result = await gno.qEval("gno.land/r/berty/social", `ListJsonUsersByPrefix("${q}", ${MAX_RESULT})`);
-    const json = await convertToJson(result);
+    const usernames = await convertToJson(result);
+    if (excludeActiveAccount) {
+      // Remove the active account's own username.
+      const currentAccount = await gno.getActiveAccount();
+      const i = usernames.indexOf(currentAccount.key.name, 0);
+      if (i >= 0) {
+        usernames.splice(i, 1);
+      }
+    }
 
-    return json;
+    return usernames;
   }
 
   async function convertToJson(result: string | undefined) {


### PR DESCRIPTION
In the search screen, set the param to true so that the search result doesn't have the user's own name. Resolves https://github.com/gnolang/dsocial/issues/65 .