### PR TITLE
chore: Render posts in reverse order, fix a small bug

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -169,7 +169,7 @@ func (post *Post) RenderPost(indent string, levels int) string {
 	str += "\n"
 	if levels > 0 {
 		if post.replies.Size() > 0 {
-			post.replies.Iterate("", "", func(key string, value interface{}) bool {
+			post.replies.ReverseIterate("", "", func(key string, value interface{}) bool {
 				str += indent + "\n"
 				str += value.(*Post).RenderPost(indent+"> ", levels-1)
 				return false

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -131,7 +131,7 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	} else {
 		posts = &userPosts.threads
 	}
-	posts.Iterate("", "", func(key string, postI interface{}) bool {
+	posts.ReverseIterate("", "", func(key string, postI interface{}) bool {
 		str += "----------------------------------------\n"
 		str += postI.(*Post).RenderSummary() + "\n"
 		return false

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -243,7 +243,7 @@ func (userPosts *UserPosts) refreshHomePosts() {
 		startKey := minStartKey
 		if info.startedPostsCtr > userPosts.lastRefreshId {
 			// Started following after the last refresh. Ignore messages before started following.
-			startKey := postIDKey(info.startedPostsCtr + 1)
+			startKey = postIDKey(info.startedPostsCtr + 1)
 		}
 
 		followedUserPosts.threads.Iterate(startKey, "", func(id string, postI interface{}) bool {


### PR DESCRIPTION
* fix a bug in refreshHomePosts for updating `startKey`. (This was caught by the new lint operation when gnodev loads the realm code.)
* In the web page Render, show posts and replies in reverse order, like the dSocial app.