### PR TITLE
chore: indexer-service: In getPostID, trim whitespace before parsing

### DIFF
--- a/tools/indexer-service/graphql_client.go
+++ b/tools/indexer-service/graphql_client.go
@@ -44,6 +44,7 @@ func getOrCreateUserPosts(userAddr string) *UserPosts {
 }
 
 func getPostID(response string) (int, error) {
+	response = strings.TrimSpace(response)
 	const postIDSuffix = " gno.land/r/berty/social.PostID)"
 	if !strings.HasSuffix(response, postIDSuffix) {
 		return 0, errors.New("Expected PostID suffix: " + response)


### PR DESCRIPTION
A recent gno commit changed the realm call response from "(1 gno.land/r/berty/social.PostID)" to "(1 gno.land/r/berty/social.PostID)\n\n". Therefore, we need to trim ending whitespace before parsing.