### PR TITLE
fix: In [account] fetchData, set totalPosts with fetchThreadPosts for other user

### DIFF
--- a/mobile/app/[account]/index.tsx
+++ b/mobile/app/[account]/index.tsx
@@ -49,8 +49,14 @@ export default function Page() {
       const { following } = await search.GetJsonFollowing(response.address);
       setFollowing(following);
 
-      const total = await feed.fetchCount(response.address);
-      setTotalPosts(total);
+      if (response.address === currentUser.address) {
+        const total = await feed.fetchCount(response.address);
+        setTotalPosts(total);
+      } else {
+        // Set startIndex and endIndex to 0 to just get the n_posts.
+        const r = await feed.fetchThreadPosts(response.address, 0, 0);
+        setTotalPosts(r.n_posts);
+      }
 
       const enrichFollows = async (follows: Following[]) => {
         for await (const item of follows) {

--- a/mobile/app/[account]/index.tsx
+++ b/mobile/app/[account]/index.tsx
@@ -49,7 +49,8 @@ export default function Page() {
       const { following } = await search.GetJsonFollowing(response.address);
       setFollowing(following);
 
-      if (response.address === currentUser.address) {
+      const isUserFeed = response.address === currentUser.address
+      if (isUserFeed) {
         const total = await feed.fetchCount(response.address);
         setTotalPosts(total);
       } else {


### PR DESCRIPTION
[account] `fetchData` calls `setTotalPosts`. Currently, it calls `feed.fetchCount` which is for the current user's home feed. But this is also used to display another user's profile. This PR checks `currentUser.address` and if it is not for the current user then it calls `feed.fetchThreadPosts` to get the count of the other user's top-level threads.

(Note that this also makes it independent of the dSocial indexer, so that it's possible to view another user's posts when the indexer is down.)