### PR TITLE
chore: Add "stub" Firebase config files without secrets

### DIFF
--- a/mobile/GoogleService-Info.plist
+++ b/mobile/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>PutTheRealKeyHere</string>
+	<key>GCM_SENDER_ID</key>
+	<string>30712791745</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>tech.berty.dsocial.ios</string>
+	<key>PROJECT_ID</key>
+	<string>dsocial-fed6b</string>
+	<key>STORAGE_BUCKET</key>
+	<string>dsocial-fed6b.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:30712791745:ios:91c4123c2f1af3d52b8a40</string>
+</dict>
+</plist>

--- a/mobile/google-services.json
+++ b/mobile/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "30712791745",
+    "project_id": "dsocial-fed6b",
+    "storage_bucket": "dsocial-fed6b.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:30712791745:android:e34f5ef2d7c144342b8a40",
+        "android_client_info": {
+          "package_name": "tech.berty.dsocial.android"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "PutTheRealKeyHere"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
The Makefile requires the presence of `GoogleService-Info.plist` and `google-services.json` config files, but we don't want to include the actual files since they have secrets. This PR adds the files without the secrets so that it is possible to build dSocial for local testing (without notifications). To make the production build, it is necessary to copy the correct config files. These files are in `.gitignore` so they won't be committed to the repo.