### PR TITLE
fix: Use gnonative NPM 1.3.2. Use gnolang 1.22.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21.7
+golang 1.22.5

--- a/mobile/.tool-versions
+++ b/mobile/.tool-versions
@@ -2,4 +2,4 @@ nodejs 21.7.3
 ruby 3.2.2
 cocoapods 1.15.2
 java openjdk-17.0.2
-golang 1.21.7
+golang 1.22.5

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -16,7 +16,7 @@
         "@bufbuild/protobuf": "^1.6.0",
         "@connectrpc/connect": "^1.2.1",
         "@connectrpc/connect-web": "^1.2.1",
-        "@gnolang/gnonative": "^1.3.0",
+        "@gnolang/gnonative": "^1.3.2",
         "@reduxjs/toolkit": "^2.1.0",
         "base-64": "^1.0.0",
         "date-fns": "^3.6.0",
@@ -3586,9 +3586,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-1.3.0.tgz",
-      "integrity": "sha512-v37PqPVelxzem8ZVpA7H4W+2+atP1Lvt9ede2q92vZY7Sb3E4HjWOIlfRO+DQplqG08Xz8Qjxt+yTELs2qzseA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-1.3.2.tgz",
+      "integrity": "sha512-2iuAsjHNd3oS8Bn8XIcuPV/VwpqRn7APXYKUtv0nA+v8Wr5xK6Kwzcscby1JOAYpl2tvMd6NmEy1TmYXRuqk1w==",
       "dependencies": {
         "@buf/gnolang_gnonative.bufbuild_es": "^1.8.0-20240327143536-1ec48ff39f30.2",
         "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240327143536-1ec48ff39f30.2",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,7 +19,7 @@
     "@bufbuild/protobuf": "^1.6.0",
     "@connectrpc/connect": "^1.2.1",
     "@connectrpc/connect-web": "^1.2.1",
-    "@gnolang/gnonative": "^1.3.0",
+    "@gnolang/gnonative": "^1.3.2",
     "@reduxjs/toolkit": "^2.1.0",
     "base-64": "^1.0.0",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
The gnonative NPM 1.3.2 has the fix as described in https://github.com/gnolang/gnonative/pull/150 .
Note that this NPM version removes the unneeded iOS simulator bundle to make the package smaller, as explained in https://github.com/gnolang/gnonative/pull/151 .

Tested with iOS simulator on a fresh virtual machine.