### PR TITLE
chore: avoiding Apple Export Compliance Information on TestFlight

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -28,7 +28,10 @@
           }
         }
       },
-      "buildNumber": "9"
+      "buildNumber": "9",
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {


### PR DESCRIPTION
With this PR I'd expect not having to press that Apple button (Export Compliance Information) on every release to TestFligth.

Reference:
https://docs.expo.dev/versions/latest/sdk/securestore/#exempting-encryption-prompt

Signed-off-by: Iuri Pereira 689440+iuricmp@users.noreply.github.com