### PR TITLE
chore: Resolve ts:check errors, put in Makefile

### DIFF
--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -1,7 +1,10 @@
 check-program = $(foreach exec,$(1),$(if $(shell PATH="$(PATH)" which $(exec)),,$(error "Missing deps: no '$(exec)' in PATH")))
 check-file = $(foreach file,$(1),$(if $(wildcard $(file)),,$(error "Missing file: $(file)")))
 
-node_modules: package.json package-lock.json
+ts_check:
+	npm run ts:check
+
+node_modules: ts_check package.json package-lock.json
 	$(call check-program, npm)
 	(npm install && touch $@) || true
 .PHONY: node_modules

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -8,15 +8,19 @@ import { NotificationProvider } from "@gno/provider/notification-provider";
 import { ReduxProvider } from "redux/redux-provider";
 
 const gnoDefaultConfig = {
+  // @ts-ignore
   remote: process.env.EXPO_PUBLIC_GNO_REMOTE!,
+  // @ts-ignore
   chain_id: process.env.EXPO_PUBLIC_GNO_CHAIN_ID!,
 };
 
 const indexerDefaultConfig = {
+  // @ts-ignore
   remote: process.env.EXPO_PUBLIC_INDEXER_REMOTE!,
 };
 
 const notificationDefaultConfig = {
+  // @ts-ignore
   remote: process.env.EXPO_PUBLIC_NOTIFICATION_REMOTE!,
 };
 

--- a/mobile/components/change-network/network-list-item/index.tsx
+++ b/mobile/components/change-network/network-list-item/index.tsx
@@ -1,7 +1,7 @@
 import Icons from '@gno/components/icons';
 import Text from '@gno/components/text';
 import { colors } from '@gno/styles/colors';
-import { NetworkMetainfo } from '@gnolang/gnonative/build/hooks/types';
+import { NetworkMetainfo } from "@gno/types";
 import styled from 'styled-components/native';
 
 export interface Props {

--- a/mobile/components/change-network/network-list/index.tsx
+++ b/mobile/components/change-network/network-list/index.tsx
@@ -1,7 +1,7 @@
 import NetworkListItem from "../network-list-item";
 import styled from "styled-components/native";
 import Text from "components/text";
-import { NetworkMetainfo } from "@gnolang/gnonative/build/hooks/types";
+import { NetworkMetainfo } from "@gno/types";
 
 interface Props {
   currentChainId: string | undefined;

--- a/mobile/components/feed/post-row.tsx
+++ b/mobile/components/feed/post-row.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Image, Pressable, StyleSheet, View } from "react-native";
-import { Post } from "../../types";
+import { Post } from "@gno/types";
 import Text from "@gno/components/text";
 import RepliesLabel from "./replies-label";
 import TimeStampLabel from "./timestamp-label";

--- a/mobile/components/feed/repost-row.tsx
+++ b/mobile/components/feed/repost-row.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Image, Pressable, StyleSheet, View } from "react-native";
-import { Post } from "../../types";
+import { Post } from "@gno/types";
 import Text from "@gno/components/text";
 import RepliesLabel from "./replies-label";
 import TimeStampLabel from "./timestamp-label";

--- a/mobile/components/list/account/account-item.tsx
+++ b/mobile/components/list/account/account-item.tsx
@@ -1,6 +1,7 @@
 import Button from "@gno/components/button";
 import Spacer from "@gno/components/spacer";
-import { GnoAccount } from "@gnolang/gnonative/build/hooks/types";
+import { GnoAccount } from "@gno/types";
+
 
 interface SideMenuAccountItemProps {
   account: GnoAccount;

--- a/mobile/redux/features/signupSlice.ts
+++ b/mobile/redux/features/signupSlice.ts
@@ -263,6 +263,7 @@ const sendCoins = async (address: string) => {
     reactNative: { textStreaming: true },
   };
 
+  // @ts-ignore
   const faucetRemote = process.env.EXPO_PUBLIC_FAUCET_REMOTE;
   if (!faucetRemote) {
     throw new Error("faucet remote address is undefined");

--- a/mobile/src/grpc/transport_web.ts
+++ b/mobile/src/grpc/transport_web.ts
@@ -243,7 +243,7 @@ export function createXHRGrpcWebTransport(options: GrpcWebTransportOptions): Tra
               throw endStream.error;
             }
 
-            endStream.metadata.forEach((value, key) => trailerTarget.set(key, value));
+            endStream.metadata.forEach((value:any, key:any) => trailerTarget.set(key, value));
             continue;
           }
 

--- a/mobile/src/grpc/transport_web.ts
+++ b/mobile/src/grpc/transport_web.ts
@@ -1,5 +1,7 @@
+// @ts-ignore
 import { polyfill as polyfillReadableStream } from "react-native-polyfill-globals/src/readable-stream";
 polyfillReadableStream();
+// @ts-ignore
 import { fetch as fetchPolyfill, Headers as HeadersPolyfill } from "react-native-fetch-api";
 
 import type { AnyMessage, MethodInfo, PartialMessage, ServiceType } from "@bufbuild/protobuf";

--- a/mobile/types.ts
+++ b/mobile/types.ts
@@ -35,3 +35,21 @@ export interface GetJsonFollowingResult {
   following: Following[];
   n_following: number;
 }
+
+export type GnoConfig = {
+  Remote: string;
+  ChainID: string;
+  KeyName: string;
+  Password: string;
+  GasFee: string;
+  GasWanted: bigint;
+  Mnemonic: string;
+};
+
+export type NetworkMetainfo = {
+  chainId: string;
+  chainName: string;
+  gnoAddress: string;
+};
+
+export type GnoAccount = KeyInfo;


### PR DESCRIPTION
We want to use `npm run ts:check` in the Makefile, but first we must resolve the errors. This PR has five commits:

1. The `process.env` object is created dynamically, so ignore errors for undefined values such as `EXPO_PUBLIC_GNO_REMOTE`.
2. In types.ts, add `NetworkMetainfo` and `GnoAccount`. Correct the import to use `@gno/types`.
3. In transport_web, it complains that "Could not find a declaration file" for imported packages react-native-polyfill-globals and react-native-fetch-api. We can't change the imported packages, so ignore these errors.
4. In transport_web, add the "any" declaration to `forEach((value:any, key:any)`.
5. Now that the errors are fixed, we can update the Makefile. Add a target ts_check to do `npm run ts:check`. Add this as a dependency to the node_modules target, which is used by all the others.