### PR TITLE
chore: In mobile/Makefile, use ts_check after node_modules

### DIFF
--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -4,33 +4,33 @@ check-file = $(foreach file,$(1),$(if $(wildcard $(file)),,$(error "Missing file
 ts_check:
 	npm run ts:check
 
-node_modules: ts_check package.json package-lock.json
+node_modules: package.json package-lock.json
 	$(call check-program, npm)
 	(npm install && touch $@) || true
 .PHONY: node_modules
 
-ios: node_modules # Run the iOS app
+ios: node_modules ts_check # Run the iOS app
 	npx expo run:ios
 .PHONY: ios
 
 # - IOS
 
-ios.release_mode: node_modules # Run the iOS app in release mode
+ios.release_mode: node_modules ts_check # Run the iOS app in release mode
 	npx expo run:ios --configuration Release
 .PHONY: ios.release_mode
 
-ios.release_production: node_modules
+ios.release_production: node_modules ts_check
 	$(call check-file, GoogleService-Info.plist)
 	eas build --platform ios --profile production
 .PHONY: ios.release_production
 
 # - Android
 
-android: node_modules # Run the Android app
+android: node_modules ts_check # Run the Android app
 	npx expo run:android
 .PHONY: android
 
-android.release_production: node_modules
+android.release_production: node_modules ts_check
 	$(call check-file, google-services.json)
 	eas build --platform android --profile production
 .PHONY: android.release_production
@@ -49,7 +49,7 @@ android.reverse:
 	adb -s $(ANDROID_DEVICE) reverse tcp:26661 tcp:26661 # push notifications
 .PHONY: android.reverse
 
-start: node_modules
+start: node_modules ts_check
 	npm run start
 .PHONY: start
 


### PR DESCRIPTION
In mobile/Makefile, we want to run ts_check for most build targets. Most build targets use node_modules, so we put ts_check as a dependency of the node_modules target. But this makes ts_check run before `npm install`. This doesn't work because ts_check needs `npm install` to run first in order to install tsc.

This pull request removes ts_check for the dependency of node_modules and adds it explicitly to the dependencies of build targets _after_ node_modules.